### PR TITLE
feat: Added Access-Control-Allow-Headers

### DIFF
--- a/etc/nginx/conf.d/stagenet.xmr.ditatompel.com.conf
+++ b/etc/nginx/conf.d/stagenet.xmr.ditatompel.com.conf
@@ -31,7 +31,10 @@ server {
     add_header Strict-Transport-Security "max-age=31536000";
 
     location / {
+        # Preflight CORS
+        add_header Access-Control-Allow-Headers 'Content-Type, Origin, Accept, User-Agent, Referer';
         add_header Access-Control-Allow-Origin *;
+
         add_header Cache-Control no-cache;
 
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/etc/nginx/conf.d/testnet.xmr.ditatompel.com.conf
+++ b/etc/nginx/conf.d/testnet.xmr.ditatompel.com.conf
@@ -31,7 +31,10 @@ server {
     add_header Strict-Transport-Security "max-age=31536000";
 
     location / {
+        # Preflight CORS
+        add_header Access-Control-Allow-Headers 'Content-Type, Origin, Accept, User-Agent, Referer';
         add_header Access-Control-Allow-Origin *;
+
         add_header Cache-Control no-cache;
 
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Some client may set content-type header. If Access-Control-Allow-Headers not set, the request may fail during CORS preflight.

But still, dunno if this fixes the CORS problem. Lets see...